### PR TITLE
fix: Compilation with esp-idf 5.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,15 @@ list(APPEND srcs         "src/utils/src/espnow_mem.c"
                          "src/utils/src/espnow_utils.c")
 list(APPEND include_dirs "src/utils/include")
 
-list(APPEND requires "spi_flash" "nvs_flash" "esp_timer" "esp_wifi" "driver")
+list(APPEND requires "spi_flash" "nvs_flash" "esp_timer" "esp_wifi")
+# only need to append these if ESP-IDF is >= 5.4
+idf_build_get_property(IDF_VERSION_MAJOR IDF_VERSION_MAJOR)
+idf_build_get_property(IDF_VERSION_MINOR IDF_VERSION_MINOR)
+if(IDF_VERSION_MAJOR GREATER 5 OR (IDF_VERSION_MAJOR EQUAL 5 AND IDF_VERSION_MINOR GREATER_EQUAL 4))
+     list(APPEND requires "esp_driver_gpio" "esp_driver_uart" "esp_driver_usb_serial_jtag")
+else()
+     list(APPEND requires "driver")
+endif()
 
 idf_component_register(SRCS "${srcs}"
                        INCLUDE_DIRS "${include_dirs}"

--- a/src/espnow/src/espnow.c
+++ b/src/espnow/src/espnow.c
@@ -401,16 +401,27 @@ EXIT:
 }
 
 /**< callback function of sending ESPNOW data */
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 1)
+void espnow_send_cb(const esp_now_send_info_t *tx_info, esp_now_send_status_t status)
+#else
 void espnow_send_cb(const uint8_t *addr, esp_now_send_status_t status)
+#endif
 {
     if (g_buffered_num) {
         g_buffered_num --;
     }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 1)
+    if (!tx_info || !g_event_group) {
+        ESP_LOGW(TAG, "Send cb args error, tx_info is NULL");
+        return ;
+    }
+#else
     if (!addr || !g_event_group) {
         ESP_LOGW(TAG, "Send cb args error, addr is NULL");
         return ;
     }
+#endif
 
     if (status == ESP_NOW_SEND_SUCCESS) {
         xEventGroupSetBits(g_event_group, SEND_CB_OK);


### PR DESCRIPTION
Closes https://github.com/espressif/esp-now/issues/150

This is a copy of https://github.com/espressif/esp-now/pull/151 but done here locally since espressif/esp-now seems to be very inactive.
