### PR TITLE
feat: Allow customization of esp-now task

### DIFF
--- a/src/espnow/include/espnow.h
+++ b/src/espnow/include/espnow.h
@@ -96,6 +96,11 @@ typedef struct {
         bool sec_data               : 1;    /**< Enable or disable security data */
         uint32_t reserved2          : 18;   /**< Reserved */
     } receive_enable;            /**< Set 1 to enable receiving the corresponding ESP-NOW data type */
+    struct {
+        uint32_t stack_size_bytes;   /**< Task stack size in bytes. Increase this if you perform more work in the callbacks. */
+        int32_t core_id;             /**< Task core ID, tskNO_AFFINITY means not pinned to a core. */
+        uint8_t priority;            /**< Task priority, tskIDLE_PRIORITY is the lowest priority */
+    } task_config; /**< Task configuration for the espnow_main task. */
 } espnow_config_t;
 
 #define ESPNOW_INIT_CONFIG_DEFAULT() { \
@@ -124,6 +129,11 @@ typedef struct {
                 .sec_data      = 0, \
                 .reserved2     = 0, \
                 }, \
+    .task_config = { \
+        .stack_size_bytes = 4096, \
+        .priority = tskIDLE_PRIORITY + 1, \
+        .core_id = tskNO_AFFINITY, \
+    }, \
     }
 
 /**

--- a/src/espnow/src/espnow.c
+++ b/src/espnow/src/espnow.c
@@ -1105,7 +1105,12 @@ esp_err_t espnow_init(const espnow_config_t *config)
     ESP_LOGI(TAG, "mac: " MACSTR ", version: %d", MAC2STR(ESPNOW_ADDR_SELF), ESPNOW_VERSION);
 
     ESP_LOGI(TAG, "Enable main task");
-    xTaskCreate(espnow_main_task, "espnow_main", 4096, NULL, tskIDLE_PRIORITY + 1, NULL);
+    xTaskCreatePinnedToCore(espnow_main_task, "espnow_main",
+                            g_espnow_config->task_config.stack_size_bytes,
+                            NULL,
+                            g_espnow_config->task_config.priority,
+                            NULL,
+                            g_espnow_config->task_config.core_id);
 
     return ESP_OK;
 }


### PR DESCRIPTION
This allows users to customize the task configuration for the esp-now main task, such as stack size, priority, and core affinity. Default values are the same as the original, hard-coded ones.

This closes the upstream issue espressif/esp-now#147.

This is a duplicate of https://github.com/espressif/esp-now/pull/148 for esp-cpp/esp-now since espressif/esp-now seems inactive.
